### PR TITLE
Fixed a crash regarding the 'null' sound group in HoofprintScreen.java

### DIFF
--- a/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
+++ b/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
@@ -15,6 +15,7 @@ import folk.sisby.surveyor.terrain.WorldTerrainSummary;
 import folk.sisby.surveyor.util.RegionPos;
 import garden.hestia.hoofprint.util.ColorUtil;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -525,8 +526,13 @@ public class HoofprintScreen extends Screen {
 				editingLandmark.contains(LandmarkComponentTypes.COLOR) ? Optional.ofNullable(DyeColor.byFireworkColor(editingLandmark.get(LandmarkComponentTypes.COLOR))).map(d -> d.getName().toLowerCase()).orElse("#" + Integer.toHexString(0xFFFFFF & editingLandmark.get(LandmarkComponentTypes.COLOR)).toUpperCase()) : "white");
 			editingStyle = false;
 			updateEdited();
-			SoundEvent placeSound = Optional.ofNullable(editingLandmark.get(LandmarkComponentTypes.STACK)).filter(s -> s.getItem() instanceof BlockItem).map(s -> ((BlockItem) s.getItem()).getBlock().getSoundGroup(null).getPlaceSound()).orElse(SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT);
-			client.getSoundManager().play(PositionedSoundInstance.master(placeSound, 1.2F));
+			SoundEvent placeSound =
+				Optional.ofNullable(editingLandmark.get(LandmarkComponentTypes.STACK))
+					.filter(s -> s.getItem() instanceof BlockItem)
+					.map(s -> ((BlockItem) s.getItem()).getBlock().getSoundGroup(Blocks.AIR.getDefaultState()).getPlaceSound())
+					.orElse(SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT);
+
+			if (placeSound != null) client.getSoundManager().play(PositionedSoundInstance.master(placeSound, 1.2F));
 			if (hasShiftDown()) saveLandmark();
 			return true;
 		}

--- a/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
+++ b/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
@@ -529,7 +529,7 @@ public class HoofprintScreen extends Screen {
 			SoundEvent placeSound =
 				Optional.ofNullable(editingLandmark.get(LandmarkComponentTypes.STACK))
 					.filter(s -> s.getItem() instanceof BlockItem)
-					.map(s -> ((BlockItem) s.getItem()).getBlock().getSoundGroup(Blocks.AIR.getDefaultState()).getPlaceSound())
+					.map(s -> ((BlockItem) s.getItem()).getBlock().getSoundGroup(((BlockItem) s.getItem()).getBlock().getDefaultState()).getPlaceSound())
 					.orElse(SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT);
 
 			if (placeSound != null) client.getSoundManager().play(PositionedSoundInstance.master(placeSound, 1.2F));


### PR DESCRIPTION
Fixed a crash when right-clicking on the map

```java
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_2680.method_26204()" because "state" is null
 	    at knot//net.minecraft.class_2248.handler$ecp000$frozenlib$frozenLib$getSoundGroupOverride(class_2248.java:3166)
	    at knot//net.minecraft.class_2248.method_9573(class_2248.java)
	    at knot//garden.hestia.hoofprint.HoofprintScreen.lambda$mouseClicked$17(HoofprintScreen.java:528)
	    at java.base/java.util.Optional.map(Optional.java:260)
	    at knot//garden.hestia.hoofprint.HoofprintScreen.method_25402(HoofprintScreen.java:528)
	    at knot//net.minecraft.class_312.method_1611(class_312.java:98)
	    at knot//net.minecraft.class_437.method_25412(class_437.java:409)
	    at knot//net.minecraft.class_312.method_1601(class_312.java:98)
	    at knot//net.minecraft.class_312.method_22686(class_312.java:169)
            at knot//net.minecraft.class_1255.execute(class_1255.java:102)
	    at knot//net.minecraft.class_312.method_22684(class_312.java:169)
	    at knot//org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:43)
	    at knot//org.lwjgl.system.JNI.invokeV(Native Method)
	    at knot//org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3403)
```