### PR TITLE
Fixed crash when editingLandmark is null

### DIFF
--- a/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
+++ b/src/main/java/garden/hestia/hoofprint/HoofprintScreen.java
@@ -586,6 +586,7 @@ public class HoofprintScreen extends Screen {
 					editingLandmark = Landmark.create(SurveyorClient.getClientUuid(), Identifier.of(Hoofprint.ID, "custom/%s/%s".formatted(hoveredWorldX, hoveredWorldZ)), b -> b.add(LandmarkComponentTypes.POS, new BlockPos(hoveredWorldX, 0, hoveredWorldZ)));
 				}
 			}
+			if(editingLandmark == null) return true;
 			landmarkName = new StringBuilder(editingLandmark.getOrDefault(LandmarkComponentTypes.NAME, Text.empty()).getString());
 			landmarkStyle = new StringBuilder(editingLandmark.contains(LandmarkComponentTypes.STACK) ? Registries.ITEM.getId(editingLandmark.get(LandmarkComponentTypes.STACK).getItem()).toString().replace("minecraft:", "") :
 				editingLandmark.contains(LandmarkComponentTypes.COLOR) ? Optional.ofNullable(DyeColor.byFireworkColor(editingLandmark.get(LandmarkComponentTypes.COLOR))).map(d -> d.getName().toLowerCase()).orElse("#" + Integer.toHexString(0xFFFFFF & editingLandmark.get(LandmarkComponentTypes.COLOR)).toUpperCase()) : "white");


### PR DESCRIPTION
```
net.minecraft.class_148: mouseClicked event handler
	at net.minecraft.class_437.method_25412(class_437.java:414) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_1601(class_312.java:98) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_22686(class_312.java:169) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.execute(class_1255.java:102) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_22684(class_312.java:169) ~[client-intermediary.jar:?]
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:43) ~[lwjgl-glfw-3.3.1.jar:?]
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.3.1.jar:?]
	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3403) ~[lwjgl-glfw-3.3.1.jar:?]
	at com.mojang.blaze3d.systems.RenderSystem.pollEvents(RenderSystem.java:201) ~[client-intermediary.jar:?]
	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:219) ~[client-intermediary.jar:?]
	at net.minecraft.class_1041.method_15998(class_1041.java:288) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1523(class_310.java:1241) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1514(class_310.java:802) ~[client-intermediary.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:250) ~[minecraft-1.20.1-client.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514) ~[fabric-loader-0.18.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72) ~[fabric-loader-0.18.3.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) ~[fabric-loader-0.18.3.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:102) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) ~[NewLaunch.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "folk.sisby.surveyor.landmark.Landmark.getOrDefault(folk.sisby.surveyor.landmark.component.LandmarkComponentType, Object)" because "this.editingLandmark" is null
	at garden.hestia.hoofprint.HoofprintScreen.method_25402(HoofprintScreen.java:589) ~[hoofprint-1.2.0+1.20.jar:?]
	at net.minecraft.class_312.method_1611(class_312.java:98) ~[client-intermediary.jar:?]
	at net.minecraft.class_437.method_25412(class_437.java:409) ~[client-intermediary.jar:?]
	... 19 more
```